### PR TITLE
Create the cache dir for sqlite db in the init

### DIFF
--- a/tsg_insights/__init__.py
+++ b/tsg_insights/__init__.py
@@ -90,13 +90,15 @@ def create_app(test_config=None):
 
     # add caching
     with app.app_context():
+
+        # make sure the uploads folder exists
+        os.makedirs(app.config["UPLOADS_FOLDER"], exist_ok=True)
+
         if app.config["REQUESTS_CACHE_ON"]:
-            cache_dir = os.path.join(app.config["UPLOADS_FOLDER"], "http_cache")
-            os.makedirs(app.config["UPLOADS_FOLDER"], exist_ok=True)
             one_week_in_seconds = 60*60*24*7
             requests_cache.install_cache(
                 backend='sqlite',
-                cache_name=cache_dir,
+                cache_name=os.path.join(app.config["UPLOADS_FOLDER"], "http_cache"),
                 expire_after=one_week_in_seconds,
                 allowable_methods=('GET', 'HEAD',),
             )

--- a/tsg_insights/__init__.py
+++ b/tsg_insights/__init__.py
@@ -92,7 +92,7 @@ def create_app(test_config=None):
     with app.app_context():
         if app.config["REQUESTS_CACHE_ON"]:
             cache_dir = os.path.join(app.config["UPLOADS_FOLDER"], "http_cache")
-            os.makedirs(cache_dir, exist_ok=True)
+            os.makedirs(app.config["UPLOADS_FOLDER"], exist_ok=True)
             one_week_in_seconds = 60*60*24*7
             requests_cache.install_cache(
                 backend='sqlite',

--- a/tsg_insights/__init__.py
+++ b/tsg_insights/__init__.py
@@ -91,10 +91,12 @@ def create_app(test_config=None):
     # add caching
     with app.app_context():
         if app.config["REQUESTS_CACHE_ON"]:
+            cache_dir = os.path.join(app.config["UPLOADS_FOLDER"], "http_cache")
+            os.makedirs(cache_dir, exist_ok=True)
             one_week_in_seconds = 60*60*24*7
             requests_cache.install_cache(
                 backend='sqlite',
-                cache_name=os.path.join(app.config["UPLOADS_FOLDER"], "http_cache"),
+                cache_name=cache_dir,
                 expire_after=one_week_in_seconds,
                 allowable_methods=('GET', 'HEAD',),
             )


### PR DESCRIPTION
When the cache is enabled (default) the sqlite database needs to have a
existing directory to live in. Create it if it doesn't exist.