### PR TITLE
js: home: Decode url portion of url get parameter

### DIFF
--- a/tsg_insights/static/js/home.js
+++ b/tsg_insights/static/js/home.js
@@ -204,8 +204,9 @@ const dataFromURL = function (url) {
 }
 
 if (window.location.search.startsWith("?url=")) {
-    var url_to_fetch = window.location.search.replace("?url=", "");
-    dataFromURL(url_to_fetch);
+    var urlToFetch = window.location.search.replace("?url=", "");
+
+    dataFromURL(decodeURIComponent(urlToFetch));
 }
 
 const sendFile = function (file) {


### PR DESCRIPTION
When receiving the url get parameter decode the url before internally
submitting the "fetch from url" form.
This allows us to send the url correctly url encoded whilst still
maintaining backward compatibility with old urls.

e.g.
https://insights.threesixtygiving.org/?url=https://grantnav.threesixtygiving.org/search.json?query=%2A&default_field=%2A&sort=_score+desc&amountAwarded=10000000
vs
https://insights.threesixtygiving.org/?url=https://grantnav.threesixtygiving.org/search.json%3Fquery%3D%2522test%2Bvalley%2522%26default_field%3D%252A%26sort%3D_score%2Bdesc